### PR TITLE
Added "limit" field

### DIFF
--- a/sciencelogic/client.py
+++ b/sciencelogic/client.py
@@ -56,7 +56,7 @@ class Client(object):
                                 params=params,
                                 verify=self.verify)
 
-    def devices(self, details=False, limit):
+    def devices(self, details=False, limit=100):
         """
         Get a list of devices
 

--- a/sciencelogic/client.py
+++ b/sciencelogic/client.py
@@ -56,17 +56,20 @@ class Client(object):
                                 params=params,
                                 verify=self.verify)
 
-    def devices(self, details=False):
+    def devices(self, details=False, limit):
         """
         Get a list of devices
 
         :param details: Get the details of the devices
         :type  details: ``bool``
+        
+        :param limit: Number of devices to retrieve
+        :type details: ``int``
 
         :rtype: ``list`` of :class:`Device`
         """
-        response = self.get('api/device', {'extended_fetch': 1}
-                            if details else {})
+        response = self.get('api/device', {'extended_fetch': 1, 'limit': limit}
+                            if details else {'limit': limit})
         devices = []
         if details:
             for uri, device in response.json()['result_set'].items():


### PR DESCRIPTION
Some environments have more than the default (100 devices) number enabled for monitoring; let's include this since it's part of the API